### PR TITLE
Get Storm to emit hashtags and read in counts to cassandra

### DIFF
--- a/storm/topologies/TwitterTopStart/src/com/geoperception/bolts/HashtagEmitterBolt.java
+++ b/storm/topologies/TwitterTopStart/src/com/geoperception/bolts/HashtagEmitterBolt.java
@@ -1,0 +1,33 @@
+package com.geoperception.bolts;
+
+import backtype.storm.topology.BasicOutputCollector;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.base.BaseBasicBolt;
+import backtype.storm.tuple.Fields;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.tuple.Values;
+import twitter4j.HashtagEntity;
+
+import java.util.List;
+
+/**
+ * Created by jinxters on 4/17/15.
+ */
+public class HashtagEmitterBolt extends BaseBasicBolt {
+    @Override
+    public void execute(Tuple input, BasicOutputCollector collector) {
+
+        Long tweetId = (Long) input.getValueByField("id");
+        List<String> hashtags = (List<String>) input.getValueByField("hashTagText");
+
+        for (String hashtag : hashtags){
+            collector.emit(new Values(hashtag, tweetId));
+        }
+
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        declarer.declare(new Fields("hashtag", "tweetId"));
+    }
+}

--- a/storm/topologies/TwitterTopStart/src/com/geoperception/bolts/TweetWriteBolt.java
+++ b/storm/topologies/TwitterTopStart/src/com/geoperception/bolts/TweetWriteBolt.java
@@ -1,0 +1,106 @@
+package com.geoperception.bolts;
+
+import backtype.storm.task.OutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.base.BaseRichBolt;
+import backtype.storm.tuple.Tuple;
+import backtype.storm.utils.Utils;
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import com.datastax.driver.core.policies.DowngradingConsistencyRetryPolicy;
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.google.common.base.Preconditions;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by jinxters on 4/17/15.
+ */
+public class TweetWriteBolt extends BaseRichBolt {
+    OutputCollector outputCollector;
+    Map<String,String> config;
+    Cluster cassandraCluster;
+    Session session;
+    String component;
+    String cql;
+    PreparedStatement statement;
+
+    @Override
+    public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+        outputCollector = collector;
+        config = (Map <String,String>) stormConf;
+        cassandraCluster = setupCasandraClient(config.get("cassandra.nodes").split(","));
+        session = getSessionWithRetry(cassandraCluster, config.get("cassandra.keyspace"));
+        component = context.getThisComponentId();
+        cql = config.get(component + ".cql");
+
+        System.out.println("Statement = " + cql);
+        Preconditions.checkArgument(cql != null, "CassandraWriteBolt: " + component +
+                " is missing a cql statement in bolt config");
+
+        statement = session.prepare(cql);
+
+    }
+
+    @Override
+    public void execute(Tuple input) {
+
+        Object id = input.getValueByField("id");
+        Object content = input.getValueByField("content");
+        Object userName = input.getValueByField("userName");
+        Object createdAt = input.getValueByField("createdAt");
+        Object lat = input.getValueByField("lat");
+        Object lng = input.getValueByField("lng");
+        Object city = input.getValueByField("city");
+        Object hashtags = input.getValueByField("hashTagText");
+        Object[] tweetArray = new Object[] {content, userName, createdAt, lat, lng, city, hashtags, id};
+
+        try{
+            BoundStatement bound = statement.bind(tweetArray);
+            session.execute(bound);
+            outputCollector.ack(input);
+            System.out.println("Writing tweet to cassandra - User: " + userName);
+        }
+        catch (Throwable t) {
+            outputCollector.reportError(t);
+            outputCollector.fail(input);
+        }
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        // Not used
+    }
+
+    public static Cluster setupCasandraClient(String [] nodes){
+        //Setup Cassandra Policies
+        return Cluster.builder()
+                .withoutJMXReporting()
+                .withoutMetrics()
+                .addContactPoints(nodes)
+                .withRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE)
+                .withReconnectionPolicy(new ExponentialReconnectionPolicy(100L, TimeUnit.MINUTES.toMillis(5)))
+                .withLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy()))
+                .build();
+    }
+
+    public static Session getSessionWithRetry(Cluster cluster, String keyspace) {
+        while (true) {
+            try {
+                // Attempt connection to cluster keyspace
+                return cluster.connect(keyspace);
+            }
+            catch (NoHostAvailableException e){
+                System.err.println("All Cassandra Hosts offline. Waiting to try again");
+                Utils.sleep(1000);
+            }
+        }
+    }
+}

--- a/storm/topologies/TwitterTopStart/src/com/geoperception/topologies/GPTopology.java
+++ b/storm/topologies/TwitterTopStart/src/com/geoperception/topologies/GPTopology.java
@@ -8,12 +8,8 @@ import java.util.Properties;
 import backtype.storm.Config;
 import backtype.storm.LocalCluster;
 import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.tuple.Fields;
 import backtype.storm.utils.Utils;
-import com.geoperception.bolts.CassandraWriteBolt;
-import com.geoperception.bolts.LocationCounter;
 import com.geoperception.bolts.LocationFetch;
-import com.geoperception.bolts.PrinterBolt;
 
 import com.geoperception.spouts.BasicTwitterSpout;
 

--- a/storm/topologies/TwitterTopStart/src/resources/development.properties
+++ b/storm/topologies/TwitterTopStart/src/resources/development.properties
@@ -5,3 +5,4 @@ cassandra.keyspace=geoperception
 #### CQL for Cassandra Writer Bolts ####
 database.cql=UPDATE locations SET count = ? where name = ?;
 saveTweet.cql=UPDATE tweets SET content = ?, userName = ?, createdAt = ?, lat = ?, lng = ?, city = ?, hashtags = ? where id = ?;
+saveHashtag.cql=UPDATE hashtags SET count = ?, tweetIds = ? where hashtag = ?;


### PR DESCRIPTION
Sorry for the large commit, but we now can collect our data!

Storm now pulls in tweet data, parses the hashtags, counts the hashtag using a counter in Cassandra, and saves the associated tweet Ids so we can get related hashtags.

Woohoo!

One side note: in order to get Jacob his data for visualization, we will need to make another table that keeps track of a top(N) hashtags because in cassandra you cannot do joins, so we shall see how this stuff starts to work as we start collecting massive amounts of data.